### PR TITLE
Modified CalcDate-function for localized versions

### DIFF
--- a/src/codeunit/WorkingDays.Codeunit.al
+++ b/src/codeunit/WorkingDays.Codeunit.al
@@ -32,7 +32,7 @@ codeunit 50000 "SDH Calc Working Days"
         repeat
             IF CalenderMgmt.IsNonworkingDay(CheckDate, CustomCalenderChange) THEN
                 NonWorkingDays += 1;
-            CheckDate := CalcDate('1D', CheckDate);
+            CheckDate := CalcDate('<1D>', CheckDate);
         until (CheckDate > EndDate);
         WorkingDays := TotalDays - NonWorkingDays;
     end;


### PR DESCRIPTION
Switched `CalcDate('1D', CheckDate)` to `CalcDate('<1D>', CheckDate)` to also make it work in localized versions (e.g. de-DE)